### PR TITLE
Feature -- Build Script for Scratch Org

### DIFF
--- a/.forceignore
+++ b/.forceignore
@@ -1,0 +1,16 @@
+# List files or directories below to ignore them when running force:source:push, force:source:pull, and force:source:status
+# More information: https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_exclude_source.htm
+#
+
+package.xml
+**.settings-meta.xml
+**/README.md
+
+# LWC configuration files
+**/jsconfig.json
+**/.eslintrc.json
+
+# LWC Jest
+**/__tests__/**
+
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,43 @@
+# This file is used for Git repositories to specify intentionally untracked files that Git should ignore. 
+# If you are not using git, you can delete this file. For more information see: https://git-scm.com/docs/gitignore
+# For useful gitignore templates see: https://github.com/github/gitignore
+
+# Salesforce cache
+.sf/
+.sfdx/
+.localdevserver/
+deploy-options.json
+
+# LWC VSCode autocomplete
+**/lwc/jsconfig.json
+
+# LWC Jest coverage reports
+coverage/
+
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Dependency directories
+node_modules/
+
+# Eslint cache
+.eslintcache
+
+# MacOS system files
+.DS_Store
+
+# Windows system files
+Thumbs.db
+ehthumbs.db
+[Dd]esktop.ini
+$RECYCLE.BIN/
+
+# Local environment variables
+.env
+
+# Other 
+.history/

--- a/bin/install-scratch.bat
+++ b/bin/install-scratch.bat
@@ -1,0 +1,52 @@
+@echo OFF
+cd %CD%/..
+
+rem Set parameters
+set ORG_ALIAS=FormulaForceBook
+
+@echo:
+echo Installing FormulaForce scratch org (%ORG_ALIAS%)
+@echo:
+
+rem Install script
+echo Cleaning previous scratch org...
+cmd.exe /c sfdx force:org:delete -p -u %ORG_ALIAS% 2>NUL
+@echo:
+
+echo Creating scratch org...
+cmd.exe /c sfdx force:org:create -s -f config/project-scratch-def.json -d 30 -a %ORG_ALIAS%
+call :checkForError
+@echo:
+
+echo Pushing source...
+cmd.exe /c sfdx force:source:push
+call :checkForError
+@echo:
+
+@REM echo Assigning permission sets...
+@REM cmd.exe /c sfdx force:user:permset:assign -n FormulaForce
+@REM call :checkForError
+@REM @echo:
+
+@REM echo Importing sample data...
+@REM cmd.exe /c sfdx force:data:tree:import -p data/sample-data-plan.json
+@REM call :checkForError
+@REM @echo:
+
+rem Report install success if no error
+@echo:
+if ["%errorlevel%"]==["0"] (
+  echo Installation completed.
+  @echo:
+  cmd.exe /c sfdx force:org:open -p lightning/setup/SetupOneHome/home
+)
+
+:: ======== FN ======
+GOTO :EOF
+
+rem Display error if the install has failed
+:checkForError
+if NOT ["%errorlevel%"]==["0"] (
+    echo Installation failed.
+    exit /b
+)

--- a/bin/install-scratch.sh
+++ b/bin/install-scratch.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+SCRIPT_PATH=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+cd $SCRIPT_PATH/..
+
+# Set parameters
+ORG_ALIAS="FormulaForceBook"
+
+echo ""
+echo "Installing FormulaForce scratch org ($ORG_ALIAS)"
+echo ""
+
+# Install script
+echo "Cleaning previous scratch org..."
+sfdx force:org:delete -p -u $ORG_ALIAS &> /dev/null
+echo ""
+
+echo "Creating scratch org..." && \
+sfdx force:org:create -s -f config/project-scratch-def.json -d 30 -a $ORG_ALIAS && \
+echo "" && \
+
+echo "Pushing source..." && \
+sfdx force:source:push && \
+echo "" && \
+
+# echo "Assigning permission sets..." && \
+# sfdx force:user:permset:assign -n FormulaForce && \
+# echo "" && \
+
+# echo "Importing sample data..." && \
+# sfdx force:data:tree:import -p data/sample-data-plan.json && \
+# echo "" && \
+
+echo "Opening org..." && \
+sfdx force:org:open -p lightning/setup/SetupOneHome/home && \
+echo ""
+
+EXIT_CODE="$?"
+echo ""
+
+# Check exit code
+echo ""
+if [ "$EXIT_CODE" -eq 0 ]; then
+  echo "Installation completed."
+else
+    echo "Installation failed."
+fi
+exit $EXIT_CODE

--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -1,0 +1,20 @@
+{
+  "orgName": "FormulaForce App Development",
+  "edition": "Developer",
+  "features": [
+    "EnableSetPasswordInApi"
+  ],
+  "settings": {
+    "lightningExperienceSettings": {
+      "enableS1DesktopEnabled": true
+    },
+    "mobileSettings": {
+      "enableS1EncryptedStoragePref2": false
+    },
+    "securitySettings": {
+      "sessionSettings": {
+        "sessionTimeout": "TwelveHours"
+      }
+    }
+  }
+}

--- a/force-app/README.md
+++ b/force-app/README.md
@@ -1,0 +1,1 @@
+FormulaForce Project Source Code goes in this folder.

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -1,0 +1,11 @@
+{
+    "packageDirectories": [
+      {
+        "path": "force-app",
+        "default": true
+      }
+    ],
+    "namespace": "",
+    "sfdcLoginUrl": "https://login.salesforce.com",
+    "sourceApiVersion": "55.0"
+  }


### PR DESCRIPTION
While I am going through the various steps outlined in the book, I have been running a DX project locally.  Every DX project that I have gets a build script because I keep the duration on the scratch org pretty low (~2 days).  Because of this, I am rebuilding my local environment back to the progress point that I have made prior.   This project would benefit from something similar.  I have added the basic build scripts that were modeled by the [Salesforce DreamHouse App](https://github.com/trailheadapps/dreamhouse-lwc).   


Changes made:
* Addition of basic project files
* Addition of `bin.install-scratch.*` scripts modeled after the `trailheadapps/dreamhouse-lwc` app.




